### PR TITLE
Task/test kafka streams with topology test driver

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     implementation("no.nav.dagpenger:streams:0.2.5-SNAPSHOT")
-    implementation("no.nav.dagpenger:events:0.2.0-SNAPSHOT")
+    implementation("no.nav.dagpenger:events:0.2.1-SNAPSHOT")
     compile("org.apache.kafka:kafka-clients:$kafkaVersion")
     compile("org.apache.kafka:kafka-streams:$kafkaVersion")
     compile("io.confluent:kafka-streams-avro-serde:$confluentVersion")
@@ -56,6 +56,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:$jupiterVersion")
+    testImplementation("org.apache.kafka:kafka-streams-test-utils:$kafkaVersion")
     testImplementation("no.nav:kafka-embedded-env:2.0.1")
 }
 

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/DatalasterComponentTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/DatalasterComponentTest.kt
@@ -85,7 +85,7 @@ class DatalasterComponentTest {
 
         val vilkår = consumer.poll(Duration.ofSeconds(5)).toList()
 
-        assertEquals(vilkår.size, 1)
+        assertEquals(2, vilkår.size)
     }
 
     private fun vikårProducer(env: Environment): KafkaProducer<String, Vilkår> {

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/DatalasterTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/DatalasterTopologyTest.kt
@@ -1,0 +1,59 @@
+package no.nav.dagpenger.inntekt
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde
+import no.nav.dagpenger.events.avro.Vilkår
+import no.nav.dagpenger.streams.Topics
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.StreamsConfig
+import org.apache.kafka.streams.TopologyTestDriver
+import org.apache.kafka.streams.test.ConsumerRecordFactory
+import org.junit.jupiter.api.Test
+import java.util.Properties
+import java.util.Random
+import java.util.UUID
+import kotlin.test.assertTrue
+
+class DatalasterTopologyTest {
+
+    companion object {
+        val mockSchemaRegistryClient = MockSchemaRegistryClient().apply {
+            register(Topics.VILKÅR_EVENT.name, Vilkår.getClassSchema())
+        }
+        val vilkårSerDes = SpecificAvroSerde<Vilkår>(mockSchemaRegistryClient).apply {
+            configure(mapOf(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG to "bogus"), false)
+        }
+        val factory = ConsumerRecordFactory<String, Vilkår>(
+                Topics.VILKÅR_EVENT.name,
+                Serdes.String().serializer(),
+                vilkårSerDes.serializer()
+        )
+
+        val config = Properties().apply {
+            this[StreamsConfig.APPLICATION_ID_CONFIG] = "test"
+            this[StreamsConfig.BOOTSTRAP_SERVERS_CONFIG] = "dummy:1234"
+        }
+    }
+
+    @Test
+    fun ` Should add inntekt to vilkår `() {
+        val datalaster = Datalaster(Environment(
+                username = "bogus",
+                password = "bogus"
+        ))
+
+        val innVilkår = Vilkår.newBuilder().apply {
+            aktorId = Random().nextInt().toString()
+            id = UUID.randomUUID().toString()
+            vedtaksId = Random().nextInt().toString()
+        }.build()
+
+        TopologyTestDriver(datalaster.buildTopology(mockSchemaRegistryClient), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(innVilkår)
+            topologyTestDriver.pipeInput(inputRecord)
+            val ut = topologyTestDriver.readOutput(Topics.VILKÅR_EVENT.name, Serdes.String().deserializer(), vilkårSerDes.deserializer())
+            assertTrue("Inntektsdata should have beed added") { ut.value().getInntekter() != null }
+        }
+    }
+}


### PR DESCRIPTION
Eksempel på å teste kafkastreams uten å starte kafka, schemaregister og zookeeper lokalt.

Fordeler: 
- Kjøretid per test betraktelig ned (millisekunder vs flere sekunder)
- Færre "tannhjul" som kan feile
- Letter å verifisere filtre, mappinger etc
Ulemper:
- Må omstrukterer måten vi setter opp "produksjonskode" (en refaktoring av streams vil hjelpe)
