### PR TITLE
Put spesifisert inntekt on packet

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -35,7 +35,7 @@ object Dagpenger {
     }
 
     const val Streams = "com.github.navikt:dagpenger-streams:2019.07.11-11.18.8dc134276bc5"
-    const val Events = "com.github.navikt:dagpenger-events:2019.07.11-11.07.e2ca2d968ff6"
+    const val Events = "com.github.navikt:dagpenger-events:2019.07.31-14.14.8a2572241cf8"
 }
 
 object Database {

--- a/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/JsonAdapters.kt
+++ b/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/JsonAdapters.kt
@@ -2,6 +2,8 @@ package no.nav.dagpenger.datalaster.inntekt
 
 import com.squareup.moshi.JsonAdapter
 import no.nav.dagpenger.events.inntekt.v1.Inntekt
+import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
 import no.nav.dagpenger.events.moshiInstance
 
 val inntektJsonAdapter: JsonAdapter<Inntekt> = moshiInstance.adapter(Inntekt::class.java)
+val spesifisertInntektJsonAdapter: JsonAdapter<SpesifisertInntekt> = moshiInstance.adapter(SpesifisertInntekt::class.java)

--- a/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/SpesifisertInntektHttpClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/SpesifisertInntektHttpClient.kt
@@ -4,28 +4,25 @@ import com.github.kittinunf.fuel.httpPost
 import com.github.kittinunf.fuel.moshi.moshiDeserializerOf
 import com.github.kittinunf.result.Result
 import no.nav.dagpenger.events.Problem
-import no.nav.dagpenger.events.inntekt.v1.Inntekt
+import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
 import no.nav.dagpenger.events.moshiInstance
 import java.net.URI
 import java.time.LocalDate
 
-class InntektApiHttpClient(
-    private val inntektApiUrl: String,
-    private val apiKey: String
-) : InntektApiClient {
+class SpesifisertInntektHttpClient(private val inntektApiUrl: String, private val apiKey: String) {
 
-    private val jsonRequestRequestAdapter = moshiInstance.adapter(InntektRequest::class.java)
+    private val jsonRequestRequestAdapter = moshiInstance.adapter(SpesifisertInntektRequest::class.java)
     private val problemAdapter = moshiInstance.adapter(Problem::class.java)!!
 
-    override fun getInntekt(
+    fun getSpesifisertInntekt(
         aktørId: String,
         vedtakId: Int,
         beregningsDato: LocalDate
-    ): Inntekt {
+    ): SpesifisertInntekt {
 
-        val url = "${inntektApiUrl}v1/inntekt"
+        val url = "${inntektApiUrl}v1/inntekt/spesifisert"
 
-        val requestBody = InntektRequest(
+        val requestBody = SpesifisertInntektRequest(
             aktørId,
             vedtakId,
             beregningsDato
@@ -36,7 +33,7 @@ class InntektApiHttpClient(
             header("Content-Type" to "application/json")
             header("X-API-KEY", apiKey)
             body(jsonBody)
-            responseObject(moshiDeserializerOf(inntektJsonAdapter))
+            responseObject(moshiDeserializerOf(spesifisertInntektJsonAdapter))
         }
 
         return if (result is Result.Failure) {
@@ -58,7 +55,7 @@ class InntektApiHttpClient(
     }
 }
 
-data class InntektRequest(
+private data class SpesifisertInntektRequest(
     val aktørId: String,
     val vedtakId: Int,
     val beregningsDato: LocalDate

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/DatalasterTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/DatalasterTopologyTest.kt
@@ -6,10 +6,15 @@ import no.nav.dagpenger.datalaster.inntekt.Configuration
 import no.nav.dagpenger.datalaster.inntekt.Datalaster
 import no.nav.dagpenger.datalaster.inntekt.InntektApiClient
 import no.nav.dagpenger.datalaster.inntekt.InntektApiHttpClientException
+import no.nav.dagpenger.datalaster.inntekt.SpesifisertInntektHttpClient
 import no.nav.dagpenger.datalaster.inntekt.inntektJsonAdapter
 import no.nav.dagpenger.events.Packet
 import no.nav.dagpenger.events.Problem
+import no.nav.dagpenger.events.inntekt.v1.Aktør
+import no.nav.dagpenger.events.inntekt.v1.AktørType
 import no.nav.dagpenger.events.inntekt.v1.Inntekt
+import no.nav.dagpenger.events.inntekt.v1.InntektId
+import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
 import no.nav.dagpenger.streams.Topics
 import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.TopologyTestDriver
@@ -21,6 +26,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.net.URI
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.Properties
 
@@ -48,11 +54,27 @@ class DatalasterTopologyTest {
         ) = Inntekt("12345", emptyList(), sisteAvsluttendeKalenderMåned = YearMonth.now())
     }
 
+    private val emptySpesifisertInntekt = SpesifisertInntekt(
+        inntektId = InntektId("01DHGJ2NDVV2TDSPT8K9FXMAN7"),
+        avvik = emptyList(),
+        posteringer = emptyList(),
+        ident = Aktør(AktørType.AKTOER_ID, "111"),
+        manueltRedigert = false,
+        timestamp = LocalDateTime.of(2019, 5, 3, 1, 1)
+    )
+
     @Test
-    fun `Should add inntekt to packet`() {
+    fun `Should add spesifisert inntekt to packet`() {
+        val spesifisertInntektHttpClientMock: SpesifisertInntektHttpClient = mockk()
+
+        every {
+            spesifisertInntektHttpClientMock.getSpesifisertInntekt(any(), any(), any())
+        } returns emptySpesifisertInntekt
+
         val datalaster = Datalaster(
             Configuration(),
-            DatalasterTopologyTest.DummyInntektApiClient()
+            DummyInntektApiClient(),
+            spesifisertInntektHttpClientMock
         )
 
         val packetJson = """
@@ -91,10 +113,155 @@ class DatalasterTopologyTest {
     }
 
     @Test
-    fun `Should ignore packet with inntekt `() {
+    fun `Should add problem to packet if error when fetching spesifisert inntekt occurs `() {
+        val spesifisertInntektHttpClientMock: SpesifisertInntektHttpClient = mockk()
+
+        every {
+            spesifisertInntektHttpClientMock.getSpesifisertInntekt(any(), any(), any())
+        } throws InntektApiHttpClientException("", Problem(title = "failed"))
+
         val datalaster = Datalaster(
             Configuration(),
-            DatalasterTopologyTest.DummyInntektApiClient()
+            DummyInntektApiClient(),
+            spesifisertInntektHttpClientMock
+        )
+
+        val packetJson = """
+            {
+                "aktørId": "12345",
+                "vedtakId": 123,
+                "beregningsDato": 2019-01-25
+            }
+        """.trimIndent()
+
+        TopologyTestDriver(datalaster.buildTopology(), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(Packet(packetJson))
+            topologyTestDriver.pipeInput(inputRecord)
+            val ut = topologyTestDriver.readOutput(
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
+            )
+
+            assertNotNull(ut)
+            assertTrue { ut.value().hasProblem() }
+        }
+    }
+
+    @Test
+    fun `Should ignore packet with spesifisert inntekt `() {
+        val datalaster = Datalaster(
+            Configuration(),
+            DummyInntektApiClient(),
+            mockk(relaxed = true)
+        )
+
+        val packetJson = """
+            {
+                "aktørId": "12345",
+                "vedtakId": 123,
+                "beregningsDato": 2019-01-25,
+                "spesifisertInntektV1": "something"
+            }
+        """.trimIndent()
+
+        TopologyTestDriver(datalaster.buildTopology(), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(Packet(packetJson))
+            topologyTestDriver.pipeInput(inputRecord)
+            val ut = topologyTestDriver.readOutput(
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
+            )
+
+            assertNull(ut)
+        }
+    }
+
+    @Test
+    fun `Should add klassifisert inntekt to packet`() {
+        val datalaster = Datalaster(
+            Configuration(),
+            DatalasterTopologyTest.DummyInntektApiClient(),
+            mockk(relaxed = true)
+        )
+
+        val packetJson = """
+            {
+                "aktørId": "12345",
+                "vedtakId": 123,
+                "beregningsDato": 2019-01-25,
+                "otherField": "should be unchanged"
+            }
+        """.trimIndent()
+
+        TopologyTestDriver(datalaster.buildTopology(), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(Packet(packetJson))
+            topologyTestDriver.pipeInput(inputRecord)
+            val ut = topologyTestDriver.readOutput(
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
+            )
+
+            assertTrue { ut != null }
+            assertTrue(ut.value().hasField("inntektV1"))
+            assertEquals(
+                "12345",
+                ut.value().getObjectValue("inntektV1") { serialized ->
+                    checkNotNull(
+                        inntektJsonAdapter.fromJsonValue(serialized)
+                    )
+                }.inntektsId
+            )
+            assertEquals("12345", ut.value().getStringValue("aktørId"))
+            assertEquals(123, ut.value().getIntValue("vedtakId"))
+            assertEquals(LocalDate.of(2019, 1, 25), ut.value().getLocalDate("beregningsDato"))
+            assertEquals("should be unchanged", ut.value().getStringValue("otherField"))
+        }
+    }
+
+    @Test
+    fun `Should add problem to packet if error when fetching klassifisert inntekt occurs `() {
+        val mockInntektApiClient: InntektApiClient = mockk()
+        every {
+            mockInntektApiClient.getInntekt(any(), any(), any())
+        } throws InntektApiHttpClientException("", Problem(title = "failed"))
+
+        val datalaster = Datalaster(
+            Configuration(),
+            mockInntektApiClient,
+            mockk(relaxed = true)
+        )
+
+        val packetJson = """
+            {
+                "aktørId": "12345",
+                "vedtakId": 123,
+                "beregningsDato": 2019-01-25
+            }
+        """.trimIndent()
+
+        TopologyTestDriver(datalaster.buildTopology(), config).use { topologyTestDriver ->
+            val inputRecord = factory.create(Packet(packetJson))
+            topologyTestDriver.pipeInput(inputRecord)
+            val ut = topologyTestDriver.readOutput(
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
+                Topics.DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
+            )
+
+            assertNotNull(ut)
+            assertTrue { ut.value().hasProblem() }
+        }
+    }
+
+    @Test
+    fun `Should ignore packet with klassifisert inntekt `() {
+        val datalaster = Datalaster(
+            Configuration(),
+            DatalasterTopologyTest.DummyInntektApiClient(),
+            mockk(relaxed = true)
         )
 
         val packetJson = """
@@ -123,8 +290,8 @@ class DatalasterTopologyTest {
     fun `Should ignore packet with manuelt grunnlag `() {
         val datalaster = Datalaster(
             Configuration(),
-
-            DatalasterTopologyTest.DummyInntektApiClient()
+            DatalasterTopologyTest.DummyInntektApiClient(),
+            mockk()
         )
 
         val packetJson = """
@@ -150,46 +317,12 @@ class DatalasterTopologyTest {
     }
 
     @Test
-    fun `Should add problem to packet if error when fetching inntekt occurs `() {
-        val mockInntektApiClient: InntektApiClient = mockk()
-        every {
-            mockInntektApiClient.getInntekt(any(), any(), any())
-        } throws InntektApiHttpClientException("", Problem(title = "failed"))
-
-        val datalaster = Datalaster(
-            Configuration(),
-            mockInntektApiClient
-        )
-
-        val packetJson = """
-            {
-                "aktørId": "12345",
-                "vedtakId": 123,
-                "beregningsDato": 2019-01-25
-            }
-        """.trimIndent()
-
-        TopologyTestDriver(datalaster.buildTopology(), config).use { topologyTestDriver ->
-            val inputRecord = factory.create(Packet(packetJson))
-            topologyTestDriver.pipeInput(inputRecord)
-            val ut = topologyTestDriver.readOutput(
-                Topics.DAGPENGER_BEHOV_PACKET_EVENT.name,
-                Topics.DAGPENGER_BEHOV_PACKET_EVENT.keySerde.deserializer(),
-                Topics.DAGPENGER_BEHOV_PACKET_EVENT.valueSerde.deserializer()
-            )
-
-            assertNotNull(ut)
-            assertTrue { ut.value().hasProblem() }
-        }
-    }
-
-    @Test
     fun `Should ignore packets with problem `() {
-        val mockInntektApiClient: InntektApiClient = mockk()
 
         val datalaster = Datalaster(
             Configuration(),
-            mockInntektApiClient
+            mockk(),
+            mockk()
         )
 
         val packetJson = """
@@ -225,7 +358,8 @@ class DatalasterTopologyTest {
 
         val datalaster = Datalaster(
             Configuration(),
-            DatalasterTopologyTest.DummyInntektApiClient()
+            DatalasterTopologyTest.DummyInntektApiClient(),
+            mockk(relaxed = true)
         )
 
         val packet = Packet()

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/SpesifisertInntektHttpClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/SpesifisertInntektHttpClientTest.kt
@@ -1,0 +1,145 @@
+package no.nav.dagpenger.inntekt
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+
+import com.github.tomakehurst.wiremock.matching.EqualToPattern
+import no.nav.dagpenger.datalaster.inntekt.InntektApiHttpClientException
+import no.nav.dagpenger.datalaster.inntekt.SpesifisertInntektHttpClient
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SpesifisertInntektHttpClientTest {
+
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun configure() {
+        WireMock.configureFor(server.port())
+    }
+
+    @Test
+    fun `fetch spesifisert inntekt on 200 ok`() {
+
+        val responseBodyJson = SpesifisertInntektHttpClientTest::class.java
+            .getResource("/test-data/example-spesifisert-inntekt-payload.json").readText()
+
+        WireMock.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/v1/inntekt/spesifisert"))
+                .withHeader("X-API-KEY", EqualToPattern("api-key"))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBodyJson)
+                )
+        )
+
+        val spesifisertInntektHttpClient = SpesifisertInntektHttpClient(
+            server.url(""),
+            "api-key"
+        )
+
+        val spesifisertInntekt =
+            spesifisertInntektHttpClient.getSpesifisertInntekt(
+                "",
+                123,
+                LocalDate.now()
+            )
+
+        assertEquals("01D8G6FS9QGRT3JKBTA5KEE64C", spesifisertInntekt.inntektId.id)
+        assertEquals(4, spesifisertInntekt.posteringer.size)
+    }
+
+    @Test
+    fun `fetch spesifisert inntekt fails on 500 server error`() {
+
+        val responseBodyJson = """
+
+         {
+            "type": "urn:dp:error:inntektskomponenten",
+            "title": "Klarte ikke å hente inntekt for beregningen",
+            "status": 500,
+            "detail": "Innhenting av inntekt mot inntektskomponenten feilet."
+         }
+
+        """.trimIndent()
+        WireMock.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/v1/inntekt/spesifisert"))
+                .withHeader("X-API-KEY", EqualToPattern("api-key"))
+                .willReturn(
+                    WireMock.serverError()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBodyJson)
+                )
+        )
+
+        val spesifisertInntektHttpClient = SpesifisertInntektHttpClient(
+            server.url(""),
+            "api-key"
+        )
+
+        val inntektApiHttpClientException = assertFailsWith<InntektApiHttpClientException> {
+            spesifisertInntektHttpClient.getSpesifisertInntekt(
+                "",
+                123,
+                LocalDate.now()
+            )
+        }
+
+        val problem = inntektApiHttpClientException.problem
+        assertEquals("urn:dp:error:inntektskomponenten", problem.type.toASCIIString())
+        assertEquals("Klarte ikke å hente inntekt for beregningen", problem.title)
+        assertEquals(500, problem.status)
+        assertEquals("Innhenting av inntekt mot inntektskomponenten feilet.", problem.detail)
+    }
+
+    @Test
+    fun `fetch spesifisert inntekt fails on error and no body`() {
+
+        WireMock.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/v1/inntekt/spesifisert"))
+                .willReturn(
+                    WireMock.serviceUnavailable()
+                )
+        )
+
+        val spesifisertInntektHttpClient = SpesifisertInntektHttpClient(
+            server.url(""),
+            "api-"
+        )
+
+        val inntektApiHttpClientException = assertFailsWith<InntektApiHttpClientException> {
+            spesifisertInntektHttpClient.getSpesifisertInntekt(
+                "",
+                123,
+                LocalDate.now()
+            )
+        }
+
+        val problem = inntektApiHttpClientException.problem
+        assertEquals("urn:dp:error:inntektskomponenten", problem.type.toASCIIString())
+        assertEquals("Klarte ikke å hente inntekt", problem.title)
+        assertEquals(500, problem.status)
+    }
+}

--- a/src/test/resources/test-data/example-spesifisert-inntekt-payload.json
+++ b/src/test/resources/test-data/example-spesifisert-inntekt-payload.json
@@ -1,0 +1,118 @@
+{
+  "inntektId": {
+    "id": "01D8G6FS9QGRT3JKBTA5KEE64C"
+  },
+  "avvik": [],
+  "posteringer": [
+    {
+      "posteringsMåned": "2019-01",
+      "beløp": "250000",
+      "fordel": "kontantytelse",
+      "inntektskilde": "A-ordningen",
+      "inntektsstatus": "LoependeInnrapportert",
+      "inntektsperiodetype": "Maaned",
+      "leveringstidspunkt": "2019-02",
+      "utbetaltIMåned": "2018-03",
+      "opplysningspliktig": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "virksomhet": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "inntektsmottaker": {
+        "aktørType": "NATURLIG_IDENT",
+        "identifikator": "99999999999"
+      },
+      "inngårIGrunnlagForTrekk": true,
+      "utløserArbeidsgiveravgift": true,
+      "informasjonsstatus": "InngaarAlltid",
+      "posteringsType": "L_FASTLØNN"
+    },
+    {
+      "posteringsMåned": "2018-03",
+      "beløp": "250000",
+      "fordel": "kontantytelse",
+      "inntektskilde": "A-ordningen",
+      "inntektsstatus": "LoependeInnrapportert",
+      "inntektsperiodetype": "Maaned",
+      "leveringstidspunkt": "2019-02",
+      "utbetaltIMåned": "2018-03",
+      "opplysningspliktig": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "virksomhet": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "inntektsmottaker": {
+        "aktørType": "NATURLIG_IDENT",
+        "identifikator": "99999999999"
+      },
+      "inngårIGrunnlagForTrekk": true,
+      "utløserArbeidsgiveravgift": true,
+      "informasjonsstatus": "InngaarAlltid",
+      "posteringsType": "L_FASTLØNN"
+    },
+    {
+      "posteringsMåned": "2017-04",
+      "beløp": "250000",
+      "fordel": "kontantytelse",
+      "inntektskilde": "A-ordningen",
+      "inntektsstatus": "LoependeInnrapportert",
+      "inntektsperiodetype": "Maaned",
+      "leveringstidspunkt": "2019-02",
+      "utbetaltIMåned": "2018-03",
+      "opplysningspliktig": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "virksomhet": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "inntektsmottaker": {
+        "aktørType": "NATURLIG_IDENT",
+        "identifikator": "99999999999"
+      },
+      "inngårIGrunnlagForTrekk": true,
+      "utløserArbeidsgiveravgift": true,
+      "informasjonsstatus": "InngaarAlltid",
+      "posteringsType": "L_FASTLØNN"
+    },
+    {
+      "posteringsMåned": "2017-12",
+      "beløp": "250000",
+      "fordel": "kontantytelse",
+      "inntektskilde": "A-ordningen",
+      "inntektsstatus": "LoependeInnrapportert",
+      "inntektsperiodetype": "Maaned",
+      "leveringstidspunkt": "2019-02",
+      "utbetaltIMåned": "2018-03",
+      "opplysningspliktig": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "virksomhet": {
+        "aktørType": "ORGANISASJON",
+        "identifikator": "1111111"
+      },
+      "inntektsmottaker": {
+        "aktørType": "NATURLIG_IDENT",
+        "identifikator": "99999999999"
+      },
+      "inngårIGrunnlagForTrekk": true,
+      "utløserArbeidsgiveravgift": true,
+      "informasjonsstatus": "InngaarAlltid",
+      "posteringsType": "L_FASTLØNN"
+    }
+  ],
+  "ident": {
+    "aktørType": "NATURLIG_IDENT",
+    "identifikator": "-1"
+  },
+  "manueltRedigert": false,
+  "timestamp": "2019-08-01T07:37:32.813584"
+}


### PR DESCRIPTION
Legger inntekten på kafka for at innsyn-api kan hente den.
Neste steg blir å flytte klassifiseringen av den spesifiserte inntekten hit.