### PR TITLE
Override application id.

### DIFF
--- a/nais/q2/nais.yaml
+++ b/nais/q2/nais.yaml
@@ -6,3 +6,5 @@ spec:
   env:
     - name: BEHOV_TOPIC
       value: "privat-dagpenger-behov-v1-q2"
+    - name: APPLICATION_ID
+      value: "dagpenger-inntekt-datasamler-q2"

--- a/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/Configuration.kt
@@ -48,6 +48,7 @@ data class Configuration(
 ) {
 
     data class Application(
+        val id: String = config().getOrElse(Key("application.id", stringType), "dagpenger-inntekt-datasamler"),
         val profile: Profile = config()[Key("application.profile", stringType)].let { Profile.valueOf(it) },
         val username: String = config()[Key("srvdp.datalaster.inntekt.username", stringType)],
         val password: String = config()[Key("srvdp.datalaster.inntekt.password", stringType)],

--- a/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/Datalaster.kt
+++ b/src/main/kotlin/no/nav/dagpenger/datalaster/inntekt/Datalaster.kt
@@ -21,7 +21,8 @@ class Datalaster(
     private val unleash: Unleash
 ) : River(config.application.behovTopic) {
 
-    override val SERVICE_APP_ID: String = "dagpenger-inntekt-datasamler"
+    override val SERVICE_APP_ID: String = config.application.id
+
     override val HTTP_PORT: Int = config.application.httpPort ?: super.HTTP_PORT
 
     companion object {


### PR DESCRIPTION
This is used as:

An identifier for the stream processing application.
Must be unique within the Kafka cluster.